### PR TITLE
Update mutation testing badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 [![Latest Stable Version](http://poser.pugx.org/dropelikeit/laravel-responsefactory/v)](https://packagist.org/packages/dropelikeit/laravel-responsefactory)
 [![License](https://poser.pugx.org/dropelikeit/laravel-responsefactory/license)](https://packagist.org/packages/dropelikeit/laravel-responsefactory)
 [![composer.lock](https://poser.pugx.org/dropelikeit/laravel-responsefactory/composerlock)](https://packagist.org/packages/dropelikeit/laravel-responsefactory)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Flaravel-responsefactory)](https://dashboard.stryker-mutator.io/reports/laravel-responsefactory)
-
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FDropelikeit%2Flaravel-responsefactory%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Dropelikeit/laravel-responsefactory/main)
 # ResponseFactory for Laravel
 
 The ResponseFactory is a successor to


### PR DESCRIPTION
Updated the mutation testing badge in README to reflect the correct main branch URL, aligning with the repository's branch naming conventions.