### PR TITLE
Update PHP CS Fixer version and streamline environment variable usage

### DIFF
--- a/.github/workflows/app-tester.yml
+++ b/.github/workflows/app-tester.yml
@@ -75,7 +75,7 @@ jobs:
         run: "composer test-coverage"
 
       - name: "Run PHP CS Check"
-        run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+        run: "composer cs-check"
 
       - name: "Run Psalm"
         run: "composer psalm"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
-    "friendsofphp/php-cs-fixer": "^3.74",
+    "friendsofphp/php-cs-fixer": "^3.84",
     "phpunit/phpunit": "^11.5",
     "larastan/larastan": "^3.2",
     "orchestra/testbench": "^10.1",
@@ -51,7 +51,7 @@
   "scripts": {
     "lint": "parallel-lint --exclude .git --exclude vendor .",
     "cs-check": "php-cs-fixer -v --dry-run --using-cache=no fix",
-    "cs-fix": "export PHP_CS_FIXER_IGNORE_ENV=true && php-cs-fixer --using-cache=no fix",
+    "cs-fix": "php-cs-fixer --using-cache=no fix",
     "test": "export XDEBUG_MODE=coverage && phpunit",
     "test-coverage": "export XDEBUG_MODE=coverage && phpunit --coverage-xml build/logs --coverage-clover build/logs/clover.xml --coverage-html build/logs/clover.html --log-junit build/logs/junit.xml",
     "psalm": "psalm --no-cache -c psalm.xml",


### PR DESCRIPTION
Bumped PHP CS Fixer to version ^3.84 in composer.json and removed deprecated `PHP_CS_FIXER_IGNORE_ENV` usage in scripts and workflows for cleaner configuration.